### PR TITLE
added support for `dump` function when in debug mode

### DIFF
--- a/TemplateEngineTwig.module
+++ b/TemplateEngineTwig.module
@@ -52,6 +52,11 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
             'auto_reload' => $this->getConfig('auto_reload'),
             'autoescape' => $this->getConfig('auto_escape'),
         ));
+
+        if ($this->wire('config')->debug) {
+            $this->twig->addExtension(new Twig_Extension_Debug());
+        }
+
         if ($this->getConfig('api_vars_available')) {
             foreach (Wire::getFuel() as $name => $object) {
                 if ($name == $this->factory->get('api_var')) continue;


### PR DESCRIPTION
The `dump` function is not available by default. You must add the `Twig_Extension_Debug` extension explicitly when creating your Twig environment (from [official](http://twig.sensiolabs.org/doc/functions/dump.html) documentation)