### PR TITLE
Fix Twig_Autoloader deprecation message

### DIFF
--- a/TemplateEngineTwig.module
+++ b/TemplateEngineTwig.module
@@ -1,20 +1,13 @@
 <?php
 require_once(dirname(dirname(__FILE__)) . '/TemplateEngineFactory/TemplateEngine.php');
-require_once('vendor/twig/twig/lib/Twig/Autoloader.php');
+require_once(__DIR__ . '/vendor/twig/twig/lib/Twig/Autoloader.php');
 
 /**
  * TemplateEngineTwig
  *
  * @author Stefan Wanzenried <stefan.wanzenried@gmail.com>
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License, version 2
- * @version 1.0.1
- *
- * ProcessWire 2.x
- * Copyright (C) 2014 by Ryan Cramer
- * Licensed under GNU/GPL v2, see LICENSE.TXT
- *
- * http://processwire.com
- *
+ * @version 1.0.2
  */
 class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableModule
 {
@@ -63,7 +56,6 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
                 $this->variables[$name] = $object;
             }
         }
-        $this->twig->addExtension(new Twig_Extension_Debug());
         $this->initTwig($this->twig);
     }
 
@@ -74,6 +66,7 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
     public static function getDefaultConfig()
     {
         $config = parent::getDefaultConfig();
+
         return array_merge($config, array(
             'template_files_suffix' => 'html',
             'api_vars_available' => 1,
@@ -92,22 +85,6 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
     public function set($key, $value)
     {
         $this->variables[$key] = $value;
-    }
-
-
-    /**
-     * Set multiple key/value pairs to the template
-     *
-     * @param $key
-     * @param $value
-     */
-    public function setMultiple($pairs = array())
-    {
-      if (is_array($pairs)) {
-        foreach ($pairs as $key => $value) {
-          $this->variables[$key] = $value;
-        }
-      }
     }
 
 
@@ -153,7 +130,9 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
      *
      * @param Twig_Environment $twig
      */
-    protected function ___initTwig(Twig_Environment $twig) {}
+    protected function ___initTwig(Twig_Environment $twig)
+    {
+    }
 
 
 
@@ -171,7 +150,7 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
         return array(
             'title' => 'Template Engine Twig',
             'summary' => 'Twig templates for the TemplateEngineFactory',
-            'version' => 101,
+            'version' => 102,
             'author' => 'Stefan Wanzenried (Wanze)',
             'href' => 'https://processwire.com/talk/topic/6835-module-twig-for-the-templateenginefactory/',
             'singular' => false,

--- a/TemplateEngineTwig.module
+++ b/TemplateEngineTwig.module
@@ -1,13 +1,15 @@
 <?php
 require_once(dirname(dirname(__FILE__)) . '/TemplateEngineFactory/TemplateEngine.php');
-require_once(__DIR__ . '/vendor/twig/twig/lib/Twig/Autoloader.php');
+if (!class_exists('Twig_Autoloader')) {
+    require_once(__DIR__ . '/vendor/twig/twig/lib/Twig/Autoloader.php');
+}
 
 /**
  * TemplateEngineTwig
  *
  * @author Stefan Wanzenried <stefan.wanzenried@gmail.com>
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License, version 2
- * @version 1.0.2
+ * @version 1.0.3
  */
 class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableModule
 {
@@ -150,7 +152,7 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
         return array(
             'title' => 'Template Engine Twig',
             'summary' => 'Twig templates for the TemplateEngineFactory',
-            'version' => 102,
+            'version' => 103,
             'author' => 'Stefan Wanzenried (Wanze)',
             'href' => 'https://processwire.com/talk/topic/6835-module-twig-for-the-templateenginefactory/',
             'singular' => false,

--- a/TemplateEngineTwig.module
+++ b/TemplateEngineTwig.module
@@ -1,7 +1,7 @@
 <?php
 require_once(dirname(dirname(__FILE__)) . '/TemplateEngineFactory/TemplateEngine.php');
-if (!class_exists('Twig_Autoloader')) {
-    require_once(/*NoCompile*/__DIR__ . '/vendor/twig/twig/lib/Twig/Autoloader.php');
+if (!class_exists('Twig_Compiler')) {
+    require_once (/*NoCompile*/__DIR__ . '/vendor/autoload.php');
 }
 
 /**
@@ -44,7 +44,6 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
      */
     public function initEngine()
     {
-        Twig_Autoloader::register();
         $loader = new Twig_Loader_Filesystem($this->getTemplatesPath());
         $this->twig = new Twig_Environment($loader, array(
             'cache' => $this->wire('config')->paths->assets . 'cache/' . self::COMPILE_DIR,

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-            "twig/twig": "~1.24"
+            "twig/twig": "1.24.2"
         }
 }


### PR DESCRIPTION
This PR fixes the PHP warning `Using Twig_Autoloader is deprecated since version 1.21. Use Composer instead. `. It also locks Twig library to version 1.24.2 since latest (1.34.4) is causing error with this Twig module.

Refer to https://github.com/wanze/TemplateEngineTwig/issues/10
