### PR TITLE
Make sure settings passed to Twig are boolean

### DIFF
--- a/TemplateEngineTwig.module
+++ b/TemplateEngineTwig.module
@@ -49,8 +49,8 @@ class TemplateEngineTwig extends TemplateEngine implements Module, ConfigurableM
         $this->twig = new Twig_Environment($loader, array(
             'cache' => $this->wire('config')->paths->assets . 'cache/' . self::COMPILE_DIR,
             'debug' => $this->wire('config')->debug,
-            'auto_reload' => $this->getConfig('auto_reload'),
-            'autoescape' => $this->getConfig('auto_escape'),
+            'auto_reload' => $this->getConfig('auto_reload') == 1,
+            'autoescape' => $this->getConfig('auto_escape') == 1,
         ));
 
         if ($this->wire('config')->debug) {


### PR DESCRIPTION
Twig throws the following error if non-boolean values are used:

call_user_func() expects parameter 1 to be a valid callback, no array or string given in .../vendor/twig/twig/lib/Twig/Extension/Escaper.php:80